### PR TITLE
Dev memsave

### DIFF
--- a/Makefile.clt
+++ b/Makefile.clt
@@ -90,7 +90,7 @@ Calpop_InitCalPop.cpp  \
 Calpop_precaldia.cpp  \
 Calpop_precalrec.cpp  \
 Calpop_tridag.cpp \
-Calpop_recompute_coefs.cpp \
+Calpop_recompute.cpp \
 hessian.cpp \
 like.cpp
 

--- a/Makefile.den
+++ b/Makefile.den
@@ -85,7 +85,7 @@ Calpop_InitCalPop.cpp  \
 Calpop_precaldia.cpp  \
 Calpop_precalrec.cpp  \
 Calpop_tridag.cpp \
-Calpop_recompute_coefs.cpp \
+Calpop_recompute.cpp \
 hessian.cpp \
 like.cpp
 

--- a/Makefile.flx
+++ b/Makefile.flx
@@ -89,6 +89,7 @@ Calpop_InitCalPop.cpp  \
 Calpop_precaldia.cpp  \
 Calpop_precalrec.cpp  \
 Calpop_tridag.cpp \
+hessian.cpp \
 like.cpp
 
 SRCPATH=DOM/src:src

--- a/src/Calpop_calrec.cpp
+++ b/src/Calpop_calrec.cpp
@@ -100,11 +100,6 @@ void CCalpop::calrec_GO(const PMap& map, dvar_matrix& uu)
 	int nti = map.imax+2; 
 	int ntj = map.jmax+2; 
 
-//cout << nti << " " << ntj << endl; //exit(1);
-//for (int j = map.jmin; j <= map.jmax; j++)
-//	cout << j << " " << map.iinf[j] << " "<< map.isup[j] << endl;
-//cout << map.imax << endl; exit(1);
-
 	DVECTOR uvec1(0, nti+2*ncells-3);
 	DVECTOR rhs1( 0, nti+2*ncells-3);
 	DVECTOR gam1( 0, nti+2*ncells-3);
@@ -189,7 +184,7 @@ void CCalpop::calrec_GO(const PMap& map, dvar_matrix& uu)
 
 void CCalpop::calrec_GO_with_catch(const PMap& map, CParam& param, dvar_matrix& uu, const dmatrix& C_obs, dvar_matrix& C_est)
 {
-//cout << __LINE__ << " ADI-solver for GLOBAL domain " << endl;
+//cout << __LINE__ << " ADI-solver with catch for GLOBAL domain " << endl;
 	DVECTOR uvec(0, maxn - 1);
 	DVECTOR rhs(0, maxn - 1);
 	DVECTOR gam(0, maxn - 1);
@@ -197,11 +192,6 @@ void CCalpop::calrec_GO_with_catch(const PMap& map, CParam& param, dvar_matrix& 
 	int ncells = 20;
 	int nti = map.imax+2; 
 	int ntj = map.jmax+2; 
-
-//cout << nti << " " << ntj << endl; //exit(1);
-//for (int j = map.jmin; j <= map.jmax; j++)
-//	cout << j << " " << map.iinf[j] << " "<< map.isup[j] << endl;
-//cout << map.imax << endl; exit(1);
 
 	DVECTOR uvec1(0, nti+2*ncells-3);
 	DVECTOR rhs1( 0, nti+2*ncells-3);

--- a/src/Calpop_recompute.cpp
+++ b/src/Calpop_recompute.cpp
@@ -12,6 +12,109 @@ const double rc = 0.0005;
 const double rho = 0.99;
 
 
+///This function recomputes all intermediate solutions of one forward ADI step, taking the solution from previous step.
+///Basically, it is the modified 'calrec' routine, with one less iteration in the i-loop as the adjoint code doesn't need this solution.
+void CCalpop::RecompADI_step_fwd(const PMap& map, d3_array& uu, d3_array& uuint, const dmatrix a, const dmatrix bm, const dmatrix& c, const dmatrix& d, const dmatrix& e, const dmatrix& f, const dmatrix& xbet, const dmatrix& ybet)
+{
+
+	dvector uvec(0,maxn-1);
+	dvector rhs(0,maxn-1);
+	dvector gam(0,maxn-1);
+	uvec.initialize();
+	rhs.initialize();
+	gam.initialize();
+
+	for (int itr = 1; itr <= iterationNumber; itr++) {
+	
+		for (int j = map.jmin; j <= map.jmax; j++){
+		
+			const int imin = map.iinf[j]; 
+			const int imax = map.isup[j];
+
+			for (int i = imin; i <= imax; i++)
+				if (map.jinf[i] <= j && j <= map.jsup[i])
+					rhs[i]=-d[i][j]*uu[itr-1][i][j-1] + (2*iterationNumber-e[i][j])*uu(itr-1,i,j) - f[i][j]*uu(itr-1,i,j+1);
+						
+			tridag(a[j],xbet[j],c[j],rhs,uvec,gam,imin,imax);
+
+			for (int i = imin; i <= imax; i++)
+				uuint(itr,i,j) = uvec[i];
+
+		} 	
+		if (itr < iterationNumber){
+			for (int i = map.imin; i <= map.imax; i++){
+		
+				DVECTOR& dvUUINTprev = uuint[itr][i-1];
+				DVECTOR& dvUUINT     = uuint[itr][i];
+				DVECTOR& dvUUINTnext = uuint[itr][i+1];
+
+				const int jmin = map.jinf[i];
+	    			const int jmax = map.jsup[i];
+				for (int j = jmin; j <= jmax; j++)
+					if (map.iinf[j] <= i && i <= map.isup[j])
+						rhs[j]=(-a[j][i]*dvUUINTprev[j])+(2*iterationNumber-bm[j][i])*dvUUINT[j] -(c[j][i]*dvUUINTnext[j]);
+				
+				tridag(d[i],ybet[i],f[i],rhs,uvec,gam,jmin,jmax);
+
+				for (int j = jmin; j <= jmax; j++)
+					uu(itr,i,j) = uvec[j];
+			}
+		} 
+	}
+}
+
+///This function recomputes all intermediate solutions of one forward ADI step with catch removal.
+///Basically, it is the modified 'calrec' routine, with one less iteration in the i-loop as the adjoint code doesn't need this solution.
+void CCalpop::RecompADI_step_fwd_with_catch(const PMap& map, d3_array& uu, d3_array& uuint, const dmatrix a, const dmatrix bm, const dmatrix& c, const dmatrix& d, const dmatrix& e, const dmatrix& f, const dmatrix& xbet, const dmatrix& ybet)
+{
+
+	dvector uvec(0,maxn-1);
+	dvector rhs(0,maxn-1);
+	dvector gam(0,maxn-1);
+	uvec.initialize();
+	rhs.initialize();
+	gam.initialize();
+
+	for (int itr = 1; itr <= iterationNumber; itr++) {
+	
+		for (int j = map.jmin; j <= map.jmax; j++){
+		
+			const int imin = map.iinf[j]; 
+			const int imax = map.isup[j];
+
+			for (int i = imin; i <= imax; i++)
+				if (map.jinf[i] <= j && j <= map.jsup[i])
+					rhs[i]=-d[i][j]*uu[itr-1][i][j-1] + (2*iterationNumber-e[i][j])*uu(itr-1,i,j) - f[i][j]*uu(itr-1,i,j+1);
+						
+			tridag(a[j],xbet[j],c[j],rhs,uvec,gam,imin,imax);
+
+			for (int i = imin; i <= imax; i++)
+				uuint(itr,i,j) = uvec[i];
+
+		} 	
+		if (itr < iterationNumber){
+			for (int i = map.imin; i <= map.imax; i++){
+		
+				DVECTOR& dvUUINTprev = uuint[itr][i-1];
+				DVECTOR& dvUUINT     = uuint[itr][i];
+				DVECTOR& dvUUINTnext = uuint[itr][i+1];
+
+				const int jmin = map.jinf[i];
+	    			const int jmax = map.jsup[i];
+				for (int j = jmin; j <= jmax; j++)
+					if (map.iinf[j] <= i && i <= map.isup[j])
+						rhs[j]=(-a[j][i]*dvUUINTprev[j])+(2*iterationNumber-bm[j][i])*dvUUINT[j] -(c[j][i]*dvUUINTnext[j]);
+				
+				tridag(d[i],ybet[i],f[i],rhs,uvec,gam,jmin,jmax);
+
+				for (int j = jmin; j <= jmax; j++)
+					uu(itr,i,j) = uvec[j];
+			}
+		} 
+	}
+}
+
+
 void CCalpop::RecompDiagCoef_juv(const PMap& map, CMatrices& mat, const int t_count, const dmatrix mortality, dmatrix& aa, dmatrix& bbm, dmatrix& cc, dmatrix& dd, dmatrix& ee, dmatrix& ff)
 {
 	dvector lat_correction(map.jmin,map.jmax);

--- a/src/SeapodymCoupled_OnCompFluxes.cpp
+++ b/src/SeapodymCoupled_OnCompFluxes.cpp
@@ -573,7 +573,7 @@ double SeapodymCoupled::OnRunCoupled(dvar_vector x, const bool writeoutputfiles)
 	param->total_like = value(likelihood);
 	double clike = value(likelihood)-lflike-taglike-stocklike-eFlike;
 	if (!param->scalc()) // all but sensitivity analysis
-		cout << "end of forward run, likelihood: " << 
+		cout << "end of forward run, likelihood: " << defaultfloat <<
 		clike << " " << lflike << " " << taglike << " " << stocklike << " " << eFlike << endl;
 
 	return value(likelihood);

--- a/src/SeapodymCoupled_OnReadForcing.cpp
+++ b/src/SeapodymCoupled_OnReadForcing.cpp
@@ -26,7 +26,7 @@ void SeapodymCoupled::ReadTimeSeriesData(int t, int t_series)
 
 //BUFFER ZONE to avoid biomass accumulation effect in case of artificially closed boundary					
 //Eventually move this buffer zone declaration into preparation of model forcing or topographic index
-if (param->longitudeMin>80 && param->deltaX>=60.0 && param->deltaY>=60.0) //indicate Pacific ocean domain and coarse resolution
+if (param->sp_name[0].find("skj")==0 && param->longitudeMin>80 && param->deltaX>60.0 && param->deltaY>60.0) //indicate Pacific ocean domain and coarse resolution
 //The bloc below is executed only in case of the Pacific ocean domain within the IndoPacific area.
 {					
 // to make the buffer zone in IO part of the Pacific ocean domain. This allows avoiding the problems

--- a/src/SeapodymCoupled_OnRunCoupled.cpp
+++ b/src/SeapodymCoupled_OnRunCoupled.cpp
@@ -561,7 +561,7 @@ double SeapodymCoupled::OnRunCoupled(dvar_vector x, const bool writeoutputfiles)
 	param->total_like = value(likelihood);
 	double clike = value(likelihood)-lflike-taglike-stocklike-eFlike;
 	if (!param->scalc()){ // all but sensitivity analysis
-		cout << "end of forward run, likelihood: " << 
+		cout << "end of forward run, likelihood: " << defaultfloat <<
 		clike << " " << lflike << " " << taglike << " " << stocklike << " " << eFlike << endl;
 		if (clike+lflike && writeoutputfiles)
 			OutputLikelihoodsFishery();

--- a/src/Seapodym_OnRunDensity.cpp
+++ b/src/Seapodym_OnRunDensity.cpp
@@ -355,7 +355,7 @@ double SeapodymCoupled::OnRunDensity(dvar_vector x, const bool writeoutputfiles)
 	} // end of simulation loop
 
 	param->total_like = value(likelihood);
-	cout << "end of forward run, likelihood: " << value(likelihood) << endl;
+	cout << "end of forward run, likelihood: " << defaultfloat << value(likelihood) << endl;
 
 	return value(likelihood);
 }

--- a/src/Seapodym_OnRunHabitat.cpp
+++ b/src/Seapodym_OnRunHabitat.cpp
@@ -287,7 +287,7 @@ double SeapodymCoupled::OnRunHabitat(dvar_vector x, const bool writeoutputfiles)
 	} // end of simulation loop
 
 	param->total_like = value(likelihood);
-	cout << "end of forward run, likelihood: " << value(likelihood)-eFlike<< " " << eFlike <<endl;
+	cout << "end of forward run, likelihood: " << defaultfloat << value(likelihood)-eFlike<< " " << eFlike <<endl;
 
 	return value(likelihood);
 }
@@ -312,7 +312,7 @@ void SeapodymCoupled::ReadHabitat()
         for (int n=0; n<param->nb_habitat_run_age; n++){
 		mat.habitat_input[n].allocate(1,nbt_total);
 	        for (int t=1; t<=nbt_total; t++){
-			mat.habitat_input[n][t].allocate(0, nlon_input, 0, nlat_input);
+			mat.habitat_input[n][t].allocate(1, nlon_input, 1, nlat_input);
 			mat.habitat_input[n][t].initialize();
 		}
 	}

--- a/src/calpop.h
+++ b/src/calpop.h
@@ -51,6 +51,8 @@ public:
 	void Calrec_juv(const PMap& map, CMatrices& mat, dvar_matrix& uu, dvar_matrix& mortality, const int t_count);
 	void Calrec_adult(const PMap& map, dvar_matrix& uu, dvar_matrix& mortality);
 
+	void RecompADI_step_fwd(const PMap& map, d3_array& uu, d3_array& uuint, const dmatrix a, const dmatrix bm, const dmatrix& c, const dmatrix& d, const dmatrix& e, const dmatrix& f, const dmatrix& xbet, const dmatrix& ybet);
+	void RecompADI_step_fwd_with_catch(const PMap& map, CParam& param, d3_array& uu, d3_array& uuint, d3_array& uuint_t, const dmatrix a, const dmatrix bm, const dmatrix& c, const dmatrix& d, const dmatrix& e, const dmatrix& f, const dmatrix& xbet, const dmatrix& ybet, const dmatrix& C);
 
 	void Recomp_abc_coef(const PMap& map, CMatrices& mat, const int t_count, const dmatrix& mortality, dmatrix& aa, dmatrix& bbm, dmatrix& cc);
 	void Recomp_DEF_coef(const PMap& map, CParam& param, CMatrices& mat, const int t_count, const int jday, const dmatrix& habitat, dmatrix& dd, dmatrix& ee, dmatrix& ff, dmatrix& advection_x, dmatrix& advection_y, const int sp, const int age, const double MSS, const double c_diff_fish, const double sigma_species);

--- a/src/calrec_adre.cpp
+++ b/src/calrec_adre.cpp
@@ -18,6 +18,10 @@ void CCalpop::calrec1(const PMap& map, dvar_matrix& uu, const dmatrix& mortality
 	DVECTOR uvec(0, maxn - 1);
 	DVECTOR rhs(0, maxn - 1);
 	DVECTOR gam(0, maxn - 1);
+
+	uu.save_dvar_matrix_value();
+	save_identifier_string2((char*)"One_step_calrec_uu");
+	
 	for (int itr = 1; itr <= iterationNumber; itr++) 
 	{
 		for (int j = map.jmin; j <= map.jmax; j++)
@@ -42,8 +46,6 @@ void CCalpop::calrec1(const PMap& map, dvar_matrix& uu, const dmatrix& mortality
 			for (int i = imin; i <= imax; i++)
 				uuint(i,j) = uvec[i];
 		} 
-		uu.save_dvar_matrix_value();
-		save_identifier_string2((char*)"One_step_calrec_uu");
 		
 		for (int i = map.imin; i <= map.imax; i++)
 		{

--- a/src/calrec_precalrec.cpp
+++ b/src/calrec_precalrec.cpp
@@ -18,6 +18,9 @@ void CCalpop::calrec_with_catch(const PMap& map, CParam& param, dvar_matrix& uu,
 	DVECTOR rhs(0, maxn - 1);
 	DVECTOR gam(0, maxn - 1);
 
+	uu.save_dvar_matrix_value();
+	save_identifier_string2((char*)"One_step_calrec_uu");
+
 	for (int itr = 1; itr <= iterationNumber; itr++) 
 	{
 		//cout << itr << " " << norm(value(uu)) << endl;
@@ -54,8 +57,6 @@ void CCalpop::calrec_with_catch(const PMap& map, CParam& param, dvar_matrix& uu,
 				}
 			}
 		} 
-		uu.save_dvar_matrix_value();
-		save_identifier_string2((char*)"One_step_calrec_uu");
 		
 		for (int i = map.imin; i <= map.imax; i++)
 		{

--- a/src/like.cpp
+++ b/src/like.cpp
@@ -484,8 +484,8 @@ dvariable TruncatedPoisson(PMap& map, const dmatrix data_obs, dvar_matrix& data_
 			if (map.carte[i][j]){
 				dvariable pred = data_est(i,j);
 				const double obs = data_obs(i,j);
-				if (obs>0){
-					if (pred>0)
+				if (obs>1){
+					if (pred>1)
 						likelihood += pred - obs*log(pred) + gammln(obs+1.0)+log(1-exp(-pred));
 				}
 			}


### PR DESCRIPTION
This branch extends the current master code in the adjoint calrec routines: dv_calrec_adre, dv_calrec_precalrec and dv_calrec_with_catch_precalrec. Instead of saving and restoring the intermediate PDE solutions from cmpdiff stack, this code recomputes all iterations, to retrieve all but one half and full step solutions required by the adjoint code.

A few minor changes are added as well, including the nicer output of floating point likelihood values, correction of truncated Poisson likelihood, fixe of seapodym_fluxes compilation and removal of hard-coded buffer zone, which now must be defined in the forcing data files. 