### PR TITLE
fixed compile error for gcc 11.4

### DIFF
--- a/src/seapodym_coupled.cpp
+++ b/src/seapodym_coupled.cpp
@@ -618,7 +618,7 @@ void verify_identifier_string2(char* str1) //ASSUME str1 is not null
   long int num_bytes=strlen(str1);
   char* str = new char[num_bytes+1]; 
   str[num_bytes]='\0';
-  gradient_structure::get_fp()->fread(str,num_bytes);
+  gradient_structure().get_fp()->fread(str,num_bytes);
   if(strcmp(str1,str))
   {
     cerr << "Error[" << __FILE__ << ':' << __LINE__ << "]: \"" << str << "\" != \"" << str1 << "\"\n";
@@ -643,7 +643,7 @@ string get_path(const char* parfile)
 int save_identifier_string2(char* str)
 {
   int length=strlen(str);
-  gradient_structure::get_fp()->fwrite(str,length);
+  gradient_structure().get_fp()->fwrite(str,length);
   return 0;
 }
 
@@ -651,14 +651,14 @@ void save_long_int_value(unsigned long int x)
 {
   int num_bytes = sizeof(unsigned long int); 
   void* y = (void*)&x; 
-  gradient_structure::get_fp()->fwrite(y,num_bytes);
+  gradient_structure().get_fp()->fwrite(y,num_bytes);
 }
 
 unsigned long int restore_long_int_value(void)
 {
   void* tmpout;
   int num_bytes = sizeof(unsigned long int);
-  gradient_structure::get_fp()->fread(&tmpout,num_bytes);
+  gradient_structure().get_fp()->fread(&tmpout,num_bytes);
   return (unsigned long int)tmpout;
 }
 

--- a/src/seapodym_density.cpp
+++ b/src/seapodym_density.cpp
@@ -196,7 +196,7 @@ void verify_identifier_string2(char* str1) //ASSUME str1 is not null
   long int num_bytes=strlen(str1);
   char* str = new char[num_bytes+1]; 
   str[num_bytes]='\0';
-  gradient_structure::get_fp()->fread(str,num_bytes);
+  gradient_structure().get_fp()->fread(str,num_bytes);
   if(strcmp(str1,str))
   {
     cerr << "Error[" << __FILE__ << ':' << __LINE__ << "]: \"" << str << "\" != \"" << str1 << "\"\n";
@@ -221,7 +221,7 @@ string get_path(const char* parfile)
 int save_identifier_string2(char* str)
 {
   int length=strlen(str);
-  gradient_structure::get_fp()->fwrite(str,length);
+  gradient_structure().get_fp()->fwrite(str,length);
   return 0;
 }
 
@@ -229,14 +229,14 @@ void save_long_int_value(unsigned long int x)
 {
   int num_bytes = sizeof(unsigned long int); 
   void* y = (void*)&x; 
-  gradient_structure::get_fp()->fwrite(y,num_bytes);
+  gradient_structure().get_fp()->fwrite(y,num_bytes);
 }
 
 unsigned long int restore_long_int_value(void)
 {
   void* tmpout;
   int num_bytes = sizeof(unsigned long int);
-  gradient_structure::get_fp()->fread(&tmpout,num_bytes);
+  gradient_structure().get_fp()->fread(&tmpout,num_bytes);
   return (unsigned long int)tmpout;
 }
 

--- a/src/seapodym_habitat.cpp
+++ b/src/seapodym_habitat.cpp
@@ -208,7 +208,7 @@ void verify_identifier_string2(char* str1) //ASSUME str1 is not null
   long int num_bytes=strlen(str1);
   char* str = new char[num_bytes+1]; 
   str[num_bytes]='\0';
-  gradient_structure::get_fp()->fread(str,num_bytes);
+  gradient_structure().get_fp()->fread(str,num_bytes);
   if(strcmp(str1,str))
   {
     cerr << "Error[" << __FILE__ << ':' << __LINE__ << "]: \"" << str << "\" != \"" << str1 << "\"\n";
@@ -233,7 +233,7 @@ string get_path(const char* parfile)
 int save_identifier_string2(char* str)
 {
   int length=strlen(str);
-  gradient_structure::get_fp()->fwrite(str,length);
+  gradient_structure().get_fp()->fwrite(str,length);
   return 0;
 }
 
@@ -241,14 +241,14 @@ void save_long_int_value(unsigned long int x)
 {
   int num_bytes = sizeof(unsigned long int); 
   void* y = (void*)&x; 
-  gradient_structure::get_fp()->fwrite(y,num_bytes);
+  gradient_structure().get_fp()->fwrite(y,num_bytes);
 }
 
 unsigned long int restore_long_int_value(void)
 {
   void* tmpout;
   int num_bytes = sizeof(unsigned long int);
-  gradient_structure::get_fp()->fread(&tmpout,num_bytes);
+  gradient_structure().get_fp()->fread(&tmpout,num_bytes);
   return (unsigned long int)tmpout;
 }
 


### PR DESCRIPTION
With gcc 11.4 I get the following error:

src/seapodym_coupled.cpp: In function ‘void verify_identifier_string2(char*)’:
src/seapodym_coupled.cpp:621:29: error: cannot call member function ‘DF_FILE* gradient_structure::get_fp()’ without object
  621 |   gradient_structure::get_fp()->fread(str,num_bytes);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
src/seapodym_coupled.cpp: In function ‘int save_identifier_string2(char*)’:
src/seapodym_coupled.cpp:646:29: error: cannot call member function ‘DF_FILE* gradient_structure::get_fp()’ without object
  646 |   gradient_structure::get_fp()->fwrite(str,length);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
src/seapodym_coupled.cpp: In function ‘void save_long_int_value(long unsigned int)’:
src/seapodym_coupled.cpp:654:29: error: cannot call member function ‘DF_FILE* gradient_structure::get_fp()’ without object
  654 |   gradient_structure::get_fp()->fwrite(y,num_bytes);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
src/seapodym_coupled.cpp: In function ‘long unsigned int restore_long_int_value()’:
src/seapodym_coupled.cpp:661:29: error: cannot call member function ‘DF_FILE* gradient_structure::get_fp()’ without object
  661 |   gradient_structure::get_fp()->fread(&tmpout,num_bytes);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
make: *** [Makefile:151: objs/seapodym_coupled.o] Error 1
(

I think gradient_structure::get_fp() should be replace with gradient_structure().get_fp()