### PR TITLE
fixed memory error

### DIFF
--- a/src/Param.cpp
+++ b/src/Param.cpp
@@ -37,7 +37,7 @@ void  CParam::delete_param(bool flag)
 	if ((flag) && (nb_region))
 	{
 		for (int i=0 ; i<nb_region ; i++)
-			delete [] area[i];
+			delete area[i];
 		delete [] area;
 	}
 	if (nb_EEZ) Utilities::delete1d(EEZ_name);


### PR DESCRIPTION
This fixes the following valgrind error:

==934320== Mismatched free() / delete / delete []
==934320==    at 0x484CA8F: operator delete[](void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==934320==    by 0x1AF191: CParam::delete_param(bool) (Param.cpp:40)
==934320==    by 0x1AF712: CParam::~CParam() (Param.cpp:27)
==934320==    by 0x17DBE1: ~VarParamCoupled (VarParamCoupled.h:23)
==934320==    by 0x17DBE1: ~VarParamCoupled (VarParamCoupled.h:23)
==934320==    by 0x17DBE1: SeapodymDocConsole::~SeapodymDocConsole() (SeapodymDocConsole.h:23)
==934320==    by 0x17804F: ~SeapodymCoupled (SeapodymCoupled.h:23)
==934320==    by 0x17804F: ~SeapodymCohort (SeapodymCohort.h:29)
==934320==    by 0x17804F: seapodym_cohort(char const*, int, bool, int) (seapodym_cohort.cpp:174)
==934320==    by 0x14480A: main (main_cohort.cpp:44)
==934320==  Address 0x1f678410 is 0 bytes inside a block of size 40 alloc'd
==934320==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==934320==    by 0x162338: VarParamCoupled::read(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (VarParamCoupled.cpp:1376)
==934320==    by 0x1D1869: SeapodymCoupled::EditRunCoupled(char const*) (SeapodymCoupled_EditRunCoupled.cpp:14)
==934320==    by 0x17F1FC: SeapodymCoupled::SeapodymCoupled(char const*) (SeapodymCoupled.h:20)
==934320==    by 0x17739A: SeapodymCohort (SeapodymCohort.h:16)
==934320==    by 0x17739A: seapodym_cohort(char const*, int, bool, int) (seapodym_cohort.cpp:61)
==934320==    by 0x14480A: main (main_cohort.cpp:44)
=