### PR TITLE
Add detailed likelihood breakdown in SA

### DIFF
--- a/src/SeapodymCoupled.h
+++ b/src/SeapodymCoupled.h
@@ -22,6 +22,12 @@ public:
 	}
 	virtual ~SeapodymCoupled(){/*DoesNothing*/};
 
+	double get_clike() { return sum(clike_fishery); }
+	double get_lflike() { return lflike; }
+	double get_stocklike() { return stocklike; }
+	double get_larvaelike() { return larvaelike; }
+	double get_taglike() { return taglike; }
+
 friend class tag_release;
 
 	int nvarcalc() const { return param->nvarcalc();};
@@ -100,6 +106,7 @@ private:
 	imatrix nb_rel;
 	ivector t_count_rec;
 	i3_array tagpop_age_solve;
+	double taglike;
 
 	//larvae
 	dvar_matrix Larvae_density_pred;
@@ -107,10 +114,12 @@ private:
 	ivector kinf, ksup;
 	ivector ntime_agg;
 	double elarvae_dt;
+	double larvaelike;
 	
 	//catch and length
 
-	//double lflike; // double value of lf_like
+	double lflike; // double value of lf_like
+	double stocklike;
 	dvector lflike_fishery;
 	dvector clike_fishery;
 

--- a/src/SeapodymCoupled_OnRunCoupled.cpp
+++ b/src/SeapodymCoupled_OnRunCoupled.cpp
@@ -71,10 +71,10 @@ double SeapodymCoupled::OnRunCoupled(dvar_vector x, const bool writeoutputfiles)
 	// 	LIKELIHOOD INITIALISATION SECTION       //
 	//----------------------------------------------//	
 	double clike = 0.0;
-	double lflike = 0.0;
-	double taglike = 0;
-	double stocklike = 0.0;
-	double larvaelike = 0.0;
+	lflike = 0.0;
+	taglike = 0;
+	stocklike = 0.0;
+	larvaelike = 0.0;
 	dvariable likelihood = 0.0;
 	dvariable total_stock = 0.0;
 	lflike_fishery.initialize();

--- a/src/hessian.cpp
+++ b/src/hessian.cpp
@@ -320,7 +320,22 @@ void Sensitivity_analysis(const char* parfile, const int sftype)
 		gradient_structure::set_NO_DERIVATIVES();
 		cout << "\nComputing likelihood only: " << endl << endl;
 		double like = run_sim(sc,x);//sc.run_coupled((dvar_vector)x);
-		cout << like << endl;	
+		//cout << like << endl;	
+		
+		// Get likelihood components
+		double clike = sc.get_clike();
+		double lflike = sc.get_lflike();
+		double stocklike = sc.get_stocklike();
+		double taglike = sc.get_taglike();
+		double larvaelike = sc.get_larvaelike();
+
+		// Likelihood breakdown
+		cout << "Total:	 " << like << endl;
+		cout << "Catch:	 " << clike << endl;
+		cout << "LF:	 " << lflike << endl;
+		cout << "Stock:	 " << stocklike << endl;
+		cout << "Tags:	 " << taglike << endl;
+		cout << "Larvae: " << larvaelike << endl;
 
 	}	
 	


### PR DESCRIPTION
Modified sensitivity analysis to display detailed likelihood component breakdown instead of just total likelihood.

## Changes Made

Added Public Getter Methods (SeapodymCoupled.h)
- `double get_lflike()` 
- `double get_stocklike()` 
- `double get_clike()`
- `double get_taglike()`
- `double get_larvaelike()`

Updated Variable Initialization (SeapodymCoupled_OnRunCoupled.cpp)

Converted Local Variables to private (SeapodymCoupled.h)
- `stocklike`
- `taglike`
- `larvaelike`

Modified Sensitivity Analysis Output to display detailed likelihood (hessian.cpp)

Note: This breaks the script reading sa.out (lucas/analysis/output/sa/functions.R) but I am making a pull request in seapodym-team-scripts to handle that.

