### PR TITLE
Resolves idle-workers issue and optimizes further the IO

### DIFF
--- a/src/SeapodymCohort.cpp
+++ b/src/SeapodymCohort.cpp
@@ -6,6 +6,9 @@
 #include "DistDataCollector.h"
 #include "DataProvider.h"
 
+extern double time_ic_comm, time_ic_flush, time_ic_copy, time_spawning, time_getdata, time_xreset, time_init_cohort_restart, time_init_cohort_spawning;
+extern long   n_ic;
+
 void SeapodymCohort::prerun_model()
 {
 	OnRunFirstStep();
@@ -30,19 +33,24 @@ std::vector<double> SeapodymCohort::GetCohortDensity()
 void SeapodymCohort::InitializeCohort(dvar_vector& x, DistDataCollector& dataCollector, const bool writeoutputfiles) 
 {
 
+double t_all = MPI_Wtime();
+double t_rs = 0.0;
+double t_reset = MPI_Wtime();
 	//Reset model parameters:
 	reset(x);
+time_xreset += MPI_Wtime() - t_reset;	
 
 	//----------------------------------------------//
 	//	ALLOCATE AND INITIALIZE COHORT DENSITY	//
 	//----------------------------------------------//	
 	dvarCohortDensity.allocate(map.imin1, map.imax1, map.jinf1, map.jsup1);
 	if (cohort_id < nb_age_class){ 
+t_rs = MPI_Wtime();
 
 		//Initialize from restart file
 		RestoreDistributions(mat.nb_age_built);
 		dvarCohortDensity = mat.init_density_species(0,age_start);
-
+t_rs = MPI_Wtime()-t_rs;
 	} else {
 		//Initialize from spawning
 		int sp = 0;
@@ -52,32 +60,52 @@ void SeapodymCohort::InitializeCohort(dvar_vector& x, DistDataCollector& dataCol
 		
 		std::vector<double> data( dataCollector.getNumSize() );
 
+double t_block = MPI_Wtime();      
+double t_flush_acc = 0.0, t_copy_acc = 0.0;
+
 		dataCollector.startEpoch(); // should be as early as possible
- 
 		// Get density of all age class from dataCollector
 		for (int aa=param->age_mature[sp]; aa<nb_age_class; aa++){
 			
 			int chunk_id = (tstart_cohort-1)*nb_age_class + aa;
-			int index = 0;
 			dataCollector.getAsync(chunk_id, data.data());
-			dataCollector.flush(); // now the data are ready to be used
+
+double t_f = MPI_Wtime();
+			dataCollector.flush(); // now the data are ready to be used                       
+t_flush_acc += MPI_Wtime() - t_f;
+
+double t_c = MPI_Wtime();
+			int index = 0;
 			for (int i = map.imin1; i <= map.imax1; i++){
 				const int jmin1 = map.jinf1[i];
 				const int jmax1 = map.jsup1[i];
 				for (int j = jmin1 ; j <= jmax1; j++){
-					mat.dvarDensity(0,aa,i,j) = data[index];
+					//stripping out derivatives runs faster, but 
+					//need to be careful later to handle this in adjoint
+					mat.dvarDensity(0,aa).elem_value(i,j) = data[index];
 					index++;
 				}
 			}
+t_copy_acc += MPI_Wtime() - t_c;
 		}
 		dataCollector.endEpoch(); // should be as late as possible
 
+double t_total = MPI_Wtime() - t_block;
+time_ic_flush += t_flush_acc;                      
+time_ic_copy  += t_copy_acc;                       
+time_ic_comm  += t_total - t_copy_acc;             
+++n_ic;
+		
+double t_gd = MPI_Wtime();
 		//Compute eggs at the end of t-1!	
 		getDate(jday, tstart_cohort);
 
 		// Get data from shared memory
 		getData(true);
+	
+time_getdata += MPI_Wtime()-t_gd;
 
+double t_sp = MPI_Wtime();
 		//1. Spawning habitat (ToDo:IF NEEDED, see spawning_in_hs)
 		func.Spawning_Habitat(*param, mat, map, Spawning_Habitat, 1.0, sp, tcur, jday);
 
@@ -87,6 +115,8 @@ void SeapodymCohort::InitializeCohort(dvar_vector& x, DistDataCollector& dataCol
 
 		//3: Reproduction
 		Spawning(dvarCohortDensity,Spawning_Habitat,Total_pop,jday,sp,tcur);//checked
+												    
+time_spawning += MPI_Wtime() - t_sp;
 	}
 
 	if (writeoutputfiles){
@@ -119,6 +149,9 @@ void SeapodymCohort::InitializeCohort(dvar_vector& x, DistDataCollector& dataCol
 	age = age_start;
 	past_month = month;
 	past_qtr = qtr;
+
+time_init_cohort_restart += t_rs;
+time_init_cohort_spawning += MPI_Wtime() - t_all - t_rs;
 }
 
 void SeapodymCohort::stepForward(bool writeoutputfiles)

--- a/src/SeapodymCohort.cpp
+++ b/src/SeapodymCohort.cpp
@@ -380,7 +380,20 @@ void SeapodymCohort::setShmForcing(){
 	const size_t cells = map.get_array_size();// active ragged cells per field
 	const size_t slab  = (size_t)nf * cells;  // doubles per timestep
 
-	for (int t = g0; t <= nbt_total; ++t) {
+	// Partition the timestep range [g0, nbt_total] across node-local workers.
+	// Each shm-rank reads its OWN timesteps (ReadTimeSeriesData seeks by t_series,
+	// random access) into its PRIVATE mat[g0], then writes its DISJOINT window
+	// slabs. No write conflicts: private scratch, disjoint offsets. Caller must
+	// MPI_Barrier(dp_->getShmComm()) after this returns.
+	int shmRank = dp_->getShmRank();
+	int shmSize = 1;
+	MPI_Comm_size(dp_->getShmComm(), &shmSize);
+	const int Tsteps = nbt_total - g0 + 1;                       // number of timesteps
+	const int per    = (Tsteps + shmSize - 1) / shmSize;        // ceil split
+	const int tlo    = g0 + shmRank * per;
+	const int thi    = (tlo + per < nbt_total + 1) ? (tlo + per) : (nbt_total + 1);
+
+	for (int t = tlo; t < thi; ++t) {
 		double* base = W + (size_t)(t - g0) * slab;  // this timestep's block
 		size_t  f = 0; // running field index
 
@@ -413,7 +426,7 @@ void SeapodymCohort::setShmForcing(){
 	}
 
 	// Set O2 from climatology
-	if (param->type_oxy){
+	if (param->type_oxy && dp_->isShmRoot()){
 		double* W_O2clm  = dp_->getDataPtr("forcing_O2clm");
 		const int nf_O2clm = param->get_nforcings_O2clm();
 		const size_t slab_O2clm  = (size_t)nf_O2clm * cells;  // doubles per timestep

--- a/src/main_cohort.cpp
+++ b/src/main_cohort.cpp
@@ -16,6 +16,10 @@
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
 
+double time_ic_comm = 0.0, time_ic_flush = 0.0, time_ic_copy = 0.0, time_spawning = 0.0, time_getdata = 0.0, time_xreset = 0.0, time_init_cohort_spawning = 0.0, time_init_cohort_restart = 0.0, time_io_forcing = 0.0;
+long   n_ic = 0;   // count of spawning-path inits, for per-init averages
+double time_mpi_put = 0.0, time_send = 0.0, time_idle = 0.0;
+	
 SeapodymCohort* seapodym_cohort(const char* parfile, const int cmp_regime, const bool reset_buffers, int cohort_id, gradient_structure& gs);
 void buffers_init(long int &mv, long int &mc, long int &mg, const bool grad_calc);
 void buffers_set(long int &mv, long int &mc, long int &mg);
@@ -52,6 +56,11 @@ void taskFunction(int task_id, int stepBeg, int stepEnd, MPI_Comm comm,
 		DistDataCollector* dataCollector,
 		SeapodymCohort* cohort){
 
+	static double last_task_end = -1.0;        // per-worker process, persists across calls
+	double t_in = MPI_Wtime();
+	if (last_task_end >= 0.0)
+		time_idle += t_in - last_task_end;     // <-- time spent in worker.run() waiting for dispatch	
+	
 	double tik = MPI_Wtime();
 
 	logger->info("> task id {} for steps {} to {}", task_id, stepBeg, stepEnd);
@@ -87,9 +96,9 @@ void taskFunction(int task_id, int stepBeg, int stepEnd, MPI_Comm comm,
 		std::vector<double> localData = cohort->GetCohortDensity();
 		int chunk_id = cohort->getChunkId(step);
 
-		double tik_mpi = MPI_Wtime();
+		double t_p = MPI_Wtime();
 		dataCollector->put(chunk_id, localData.data());
-		time_mpi += MPI_Wtime() - tik_mpi;
+		time_mpi_put += MPI_Wtime() - t_p;
 		logger->info("        <<< send data for step {} of task id {}", step, task_id);
 
 		int success = task_id;
@@ -98,13 +107,16 @@ void taskFunction(int task_id, int stepBeg, int stepEnd, MPI_Comm comm,
 		const int endTaskTag = 1;
 
 		logger->info("        >>> notify manager after step {} of task id {}", step, task_id);
-		tik_mpi = MPI_Wtime();
+		double t_s = MPI_Wtime();
 		MPI_Send(output, 3, MPI_INT, 0, endTaskTag, comm);
-		time_mpi += MPI_Wtime() - tik_mpi;
+		time_send += MPI_Wtime() - t_s;
 		logger->info("        <<< notify manager after step {} of task id {}", step, task_id);
 	}
 
 	time_calc += MPI_Wtime() - tak;
+
+	last_task_end = MPI_Wtime();
+
 	logger->info("< task id {} for steps {} to {}", task_id, stepBeg, stepEnd);
 }
 
@@ -250,8 +262,9 @@ int main(int argc, char** argv) {
 			//MPI_Win_fence(0, dp.win());
 			if (dp.isShmRoot())
 				cohort.setShmForcing();
-			MPI_Barrier(workerComm);   // IS TMP: publish-sync; replace with MPI_Win_fence once Alex adds it
+			MPI_Barrier(workerComm);   
 
+			time_io_forcing += MPI_Wtime()-t_shm;
 			// Bind the task function with the necessary parameters
 			auto taskFunc = std::bind(taskFunction,
 				std::placeholders::_1, // task_id
@@ -278,7 +291,20 @@ int main(int argc, char** argv) {
 	if (workerId > 0) {
 		printf("[%d] Timings calc/overhead/worker init/cohort init/comm: %10.3lf/%10.3lf/%10.3lf/%10.3lf/%10.3lf\n", workerId,
 		time_calc, time_overhead, time_worker_init, time_cohort_init, time_mpi);
+
+printf("[%d] InitCohort comm/flush/copy/init_restart,init_spawning/spawning/getdata/xreset (tot, per-init ms): "
+         "%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f s ; %.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f/%.3f ms over %ld inits\n", workerId,
+         time_ic_comm, time_ic_flush, time_ic_copy, time_init_cohort_restart, time_init_cohort_spawning, time_spawning, time_getdata, time_xreset,
+         n_ic? 1e3*time_ic_comm/n_ic:0, n_ic? 1e3*time_ic_flush/n_ic:0,
+         n_ic? 1e3*time_ic_copy/n_ic:0, n_ic? 1e3*time_init_cohort_restart/numAgeGroups:0, 
+         n_ic? 1e3*time_init_cohort_spawning/n_ic:0, n_ic? 1e3*time_spawning/n_ic:0, 
+	 n_ic? 1e3*time_getdata/n_ic:0, n_ic? 1e3*time_xreset/n_ic:0,n_ic);
+
+printf("[%d] Time IO/Put/Send/Idle: %.3f/%.3f/%.3f/%.3f ms\n",
+         workerId, 1e3*time_io_forcing, 1e3*time_mpi_put, 1e3*time_send, 1e3*time_idle);
 	}
+
+
 
 	// Finalization of MPI
 	////////////////////////////////////////////////////////////////////////

--- a/src/main_cohort.cpp
+++ b/src/main_cohort.cpp
@@ -196,7 +196,7 @@ int main(int argc, char** argv) {
 	DistDataCollector dataCollect(MPI_COMM_WORLD, numChunks, numData);
 
 	// analyze the cohort Id task dependencies
-	SeapodymCohortDependencyAnalyzer taskDeps(numAgeGroups, numTimeSteps);
+	SeapodymCohortDependencyAnalyzer taskDeps(numAgeGroups, numTimeSteps, param.age_mature[0]);
 	int numCohorts = taskDeps.getNumberOfCohorts();
 	std::map<int, int> stepBegMap = taskDeps.getStepBegMap();
 	std::map<int, int> stepEndMap = taskDeps.getStepEndMap();
@@ -260,6 +260,7 @@ int main(int argc, char** argv) {
 			//if (dp.isShmRoot())
 			//	cohort.setShmForcing();//needs to be in cohort where the reading is done, but will be done once
 			//MPI_Win_fence(0, dp.win());
+			double t_shm = MPI_Wtime();
 			if (dp.isShmRoot())
 				cohort.setShmForcing();
 			MPI_Barrier(workerComm);   

--- a/src/main_cohort.cpp
+++ b/src/main_cohort.cpp
@@ -261,9 +261,8 @@ int main(int argc, char** argv) {
 			//	cohort.setShmForcing();//needs to be in cohort where the reading is done, but will be done once
 			//MPI_Win_fence(0, dp.win());
 			double t_shm = MPI_Wtime();
-			if (dp.isShmRoot())
-				cohort.setShmForcing();
-			MPI_Barrier(workerComm);   
+			cohort.setShmForcing();          // every node-local worker reads its timestep slice
+			MPI_Barrier(dp.getShmComm());    // per-node publish-sync: all slabs visible before any read
 
 			time_io_forcing += MPI_Wtime()-t_shm;
 			// Bind the task function with the necessary parameters


### PR DESCRIPTION
Built on the previous shared memory work (test_shm)  + includes age_mature dependency fix and parallel forcing IO. The first removes the na/2 idle-worker cap (calc efficiency 94%, manager 83%); the second removes the serial forcing read, raising the wall efficiency to 48%. Measured on katsuo, with skj_fat.xml on 480 time steps. All checksums are preserved.  

**Build dependency:** since 'main()' in main_cohort.cpp uses the 3-arg SeapodymCohortDependencyAnalyzer(..., param.age_mature[0]), this branch requires 'seapodym-parallel' branch 'cda-mature', see PR https://github.com/PacificCommunity/seapodym-parallel/pull/13.  

@AlexPletzer — your last commits in phase3 are not here, but the branches seem to have diverged only in main_cohort.cpp, flagging for your review/merge.